### PR TITLE
Fix warning in unittest

### DIFF
--- a/python/recordio/recordio.py
+++ b/python/recordio/recordio.py
@@ -4,7 +4,7 @@ import os
 from distutils.sysconfig import get_config_var
 
 path = os.path.join(
-    os.path.dirname(__file__), "librecordio" + get_config_var("SO")
+    os.path.dirname(__file__), "librecordio" + get_config_var("EXT_SUFFIX")
 )
 lib = ctypes.cdll.LoadLibrary(path)
 


### PR DESCRIPTION
To resolve the warning in unittest:
```
recordio/recordio.py:8
  /work/python/recordio/recordio.py:8: DeprecationWarning: SO is deprecated, use EXT_SUFFIX
    os.path.dirname(__file__), "librecordio" + get_config_var("SO")
```