### PR TITLE
Prepare a new recordio package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 *.whl
 build/
 *egg-info/
+.eggs/
+dist/
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.5
 
 RUN apt-get update
 RUN apt-get install -y curl

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, Extension, find_packages
 
 setup(
     name="pyrecordio",
-    version="0.0.6",
+    version="0.0.7",
     description="recordio file format support",
     url="https://github.com/wangkuiyi/recordio",
     license="Apache 2.0",


### PR DESCRIPTION
We need to push a new recordio package for python version 3.5。Since Travis CI package building is not ready, I'll use the Docker image to do a manual release.