### PR TITLE
Use bufio.NewReader and add benchmark

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -1,6 +1,7 @@
 package recordio
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
@@ -109,14 +110,15 @@ func compressData(src io.Reader, compressorIndex int) (*bytes.Buffer, error) {
 
 // parse the specified chunk from r.
 func parseChunk(r io.ReadSeeker, chunkOffset int64) (*chunk, error) {
-	var e error
-	var hdr *header
-
-	if _, e = r.Seek(chunkOffset, io.SeekStart); e != nil {
+	if _, e := r.Seek(chunkOffset, io.SeekStart); e != nil {
 		return nil, fmt.Errorf("Failed to seek chunk: %v", e)
 	}
 
-	hdr, e = parseHeader(r)
+	return loadChunk(bufio.NewReader(r))
+}
+
+func loadChunk(r io.Reader) (*chunk, error) {
+	hdr, e := parseHeader(r)
 	if e != nil {
 		return nil, fmt.Errorf("Failed to parse chunk header: %v", e)
 	}

--- a/chunk.go
+++ b/chunk.go
@@ -1,7 +1,6 @@
 package recordio
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
@@ -114,10 +113,6 @@ func parseChunk(r io.ReadSeeker, chunkOffset int64) (*chunk, error) {
 		return nil, fmt.Errorf("Failed to seek chunk: %v", e)
 	}
 
-	return loadChunk(bufio.NewReader(r))
-}
-
-func loadChunk(r io.Reader) (*chunk, error) {
 	hdr, e := parseHeader(r)
 	if e != nil {
 		return nil, fmt.Errorf("Failed to parse chunk header: %v", e)


### PR DESCRIPTION
This PR adds a benchmark of RecordIO reading. The following command runs unit tests and benchmarks. 

```
go test -bench=.
```

Without `-bench=.`, it runs no benchmark.

This PR also tries to improve reading performance by creating a `bufio.Reader` for each chunk to be read. However, it doesn't seem a significant change. Maybe we should try some other way.

Before using `bufio.Reader`:
```
goos: darwin
goarch: amd64
pkg: github.com/wangkuiyi/recordio
BenchmarkRead/reading_records_00000_to_00050-4         	       5	 293563564 ns/op
BenchmarkRead/reading_records_00050_to_00100-4         	       3	 445585152 ns/op
BenchmarkRead/reading_records_00100_to_00150-4         	       5	 298169020 ns/op
PASS
ok  	github.com/wangkuiyi/recordio	8.330s
```

After using it:

```
goos: darwin
goarch: amd64
pkg: github.com/wangkuiyi/recordio
BenchmarkRead/reading_records_00000_to_00050-4         	       5	 296029121 ns/op
BenchmarkRead/reading_records_00050_to_00100-4         	       3	 455643627 ns/op
BenchmarkRead/reading_records_00100_to_00150-4         	       3	 365613422 ns/op
PASS
ok  	github.com/wangkuiyi/recordio	7.143s
```