### PR TITLE
Use binary search with Index.Locate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 .vscode/
 dist/
 __pycache__/
+*.test

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,32 @@
+package recordio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexLocate(t *testing.T) {
+	assert := assert.New(t)
+
+	idx := Index{accumChunkLens: []int{100, 200}}
+	c, o := idx.Locate(0)
+	assert.Equal(0, c)
+	assert.Equal(0, o)
+
+	c, o = idx.Locate(10)
+	assert.Equal(0, c)
+	assert.Equal(10, o)
+
+	c, o = idx.Locate(100)
+	assert.Equal(1, c)
+	assert.Equal(0, o)
+
+	c, o = idx.Locate(199)
+	assert.Equal(1, c)
+	assert.Equal(99, o)
+
+	c, o = idx.Locate(200)
+	assert.Equal(-1, c)
+	assert.Equal(-1, o)
+}

--- a/recordio_internal_test.go
+++ b/recordio_internal_test.go
@@ -58,7 +58,7 @@ func TestWriteAndRead(t *testing.T) {
 
 	idx, e := LoadIndex(bytes.NewReader(buf.Bytes()))
 	assert.Nil(e)
-	assert.Equal([]uint32{2, 1}, idx.chunkLens)
+	assert.Equal([]int{2, 3}, idx.accumChunkLens)
 	assert.Equal(
 		[]int64{0,
 			int64(4 + // magic number


### PR DESCRIPTION
This PR is the starting point of a series of performance improvements.

It replaces the successive search algorithm by the binary search in `Index.Locate`.