### PR TITLE
snappy.NewBufferedWriter v.s. snappy.NewWriter

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -85,7 +85,7 @@ func newCompressor(compressed *bytes.Buffer, compressorID int) io.WriteCloser {
 	case NoCompression:
 		return &noopCompressor{compressed}
 	case Snappy:
-		return snappy.NewBufferedWriter(compressed)
+		return snappy.NewWriter(compressed)
 	case Gzip:
 		return gzip.NewWriter(compressed)
 	}

--- a/writer.go
+++ b/writer.go
@@ -21,7 +21,7 @@ type Writer struct {
 // using the deflate algorithm given compression level.  Note that
 // level 0 means no compression and -1 means default compression.
 func NewWriter(w io.Writer, maxChunkSize, compressor int) *Writer {
-	if maxChunkSize < 0 {
+	if maxChunkSize <= 0 {
 		maxChunkSize = defaultMaxChunkSize
 	}
 


### PR DESCRIPTION
It took me a whole day to debug that under some hard-to-reproduce circumstances that the writer-generated checksum differs from the one computed from the just-read data.  After changing `snappy.NewBufferedWriter` into `snappy.NewWriter`, there seems no more such problem.