### PR TITLE
Use Go's I/O pipeline

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -23,8 +23,6 @@ func (ch *chunk) add(record []byte) {
 	ch.numBytes += len(record)
 }
 
-// dump the chunk into w, and clears the chunk and makes it ready for
-// the next add invocation.
 func (ch *chunk) dump(w io.Writer, compressorID int) error {
 	// NOTE: don't check ch.numBytes instead, because empty
 	// records are allowed.
@@ -32,28 +30,59 @@ func (ch *chunk) dump(w io.Writer, compressorID int) error {
 		return nil
 	}
 
+	// In addition to notations introduced in the function
+	// definition parseChunk, we add the following:
+	//
+	// >(buf) : a bytes.Buffer is a writer.
+	// >(compr)> : a compressor wraps a writer into another writer.
+	//
+	// Then, the pipeline of dumping a chunk looks like the
+	// following:
+	//
+	// write->(compr)>(pipe)▶(tee)>(crc32)
+	//                        ▶-copy->(buf)
+	pr, pw := io.Pipe()
+	compr := newCompressor(pw, compressorID)
+	chksum := crc32.NewIEEE()
+	br := io.TeeReader(pr, chksum)
+	var buf bytes.Buffer
+
 	// Write raw records and their lengths into data buffer.
-	var compressed bytes.Buffer
-	cw := newCompressor(&compressed, compressorID)
-	for _, r := range ch.records {
-		var rs [4]byte
-		binary.LittleEndian.PutUint32(rs[:], uint32(len(r)))
+	var e1 error
+	go func() {
+		defer func() {
+			compr.Close() // Flush data out.
+			pw.Close()    // Notify the end.
+		}()
+		for _, r := range ch.records {
+			var rs [4]byte
+			binary.LittleEndian.PutUint32(rs[:], uint32(len(r)))
 
-		if _, e := cw.Write(rs[:]); e != nil {
-			return fmt.Errorf("Failed to write record length: %v", e)
-		}
+			if _, e := compr.Write(rs[:]); e != nil {
+				e1 = fmt.Errorf("Failed to write record length: %v", e)
+				return
+			}
 
-		if _, e := cw.Write(r); e != nil {
-			return fmt.Errorf("Failed to write record: %v", e)
+			if _, e := compr.Write(r); e != nil {
+				e1 = fmt.Errorf("Failed to write record: %v", e)
+				return
+			}
 		}
+	}()
+
+	_, e := io.Copy(&buf, br)
+	if e != nil {
+		return e
 	}
-	cw.Close()
+	if e1 != nil {
+		return e1
+	}
 
 	// Write chunk header and compressed data.
 	hdr := &header{
-		checkSum:       crc32.ChecksumIEEE(compressed.Bytes()),
+		checkSum:       chksum.Sum32(),
 		compressor:     uint32(compressorID),
-		compressedSize: uint32(compressed.Len()),
+		compressedSize: uint32(buf.Len()),
 		numRecords:     uint32(len(ch.records)),
 	}
 
@@ -61,7 +90,7 @@ func (ch *chunk) dump(w io.Writer, compressorID int) error {
 		return fmt.Errorf("Failed to write chunk header: %v", e)
 	}
 
-	if _, e := w.Write(compressed.Bytes()); e != nil {
+	if _, e := w.Write(buf.Bytes()); e != nil {
 		return fmt.Errorf("Failed to write chunk data: %v", e)
 	}
 
@@ -73,14 +102,14 @@ func (ch *chunk) dump(w io.Writer, compressorID int) error {
 }
 
 type noopCompressor struct {
-	*bytes.Buffer
+	io.Writer
 }
 
 func (c *noopCompressor) Close() error {
 	return nil
 }
 
-func newCompressor(compressed *bytes.Buffer, compressorID int) io.WriteCloser {
+func newCompressor(compressed io.WriteCloser, compressorID int) io.WriteCloser {
 	switch compressorID {
 	case NoCompression:
 		return &noopCompressor{compressed}
@@ -92,7 +121,7 @@ func newCompressor(compressed *bytes.Buffer, compressorID int) io.WriteCloser {
 	return nil
 }
 
-// parse the specified chunk from r.
+// parseChunk reads and returns a chunk from r at the given offset.
 func parseChunk(r io.ReadSeeker, chunkOffset int64) (*chunk, error) {
 	if _, e := r.Seek(chunkOffset, io.SeekStart); e != nil {
 		return nil, fmt.Errorf("Failed to seek chunk: %v", e)
@@ -103,61 +132,79 @@ func parseChunk(r io.ReadSeeker, chunkOffset int64) (*chunk, error) {
 		return nil, fmt.Errorf("Failed to parse chunk header: %v", e)
 	}
 
-	var buf bytes.Buffer
-	if _, e = io.CopyN(&buf, r, int64(hdr.compressedSize)); e != nil {
-		return nil, fmt.Errorf("Failed to read chunk data: %v", e)
-	}
-
-	if hdr.checkSum != crc32.ChecksumIEEE(buf.Bytes()) {
-		return nil, fmt.Errorf("Checksum checking failed.")
-	}
-
-	deflated, e := deflateData(&buf, int(hdr.compressor))
+	// To help designing a complex I/O pipeline using Go's io
+	// package, let us introduce the following notations:
+	//
+	// ▶ : a reader
+	// > : a writer
+	// (file)▶ : an opened file is a reader
+	// >(crc32) : a CRC32 hash is a writer
+	// >(buf): a bytes.Buffer is a writer
+	// (file)▶-copy->(buf) : io.Copy copies content from a file to a buffer
+	// ▶(decomp)▶ : a decompressor wraps a reader into another reader
+	// >(pipe)▶ : io.Pipe returns a pair of reader and writer
+	// ▶(tee)>
+	//   ▶      : io.TeeReader takes a reader and a writer and returns a branch
+	//
+	// The decompressing and checksum pipeline looks as follows:
+	//
+	// (file)▶-copy->(pipe)▶(tee)>(crc32)
+	//                        ▶(decomp)▶-read
+	//
+	pr, pw := io.Pipe()
+	chksum := crc32.NewIEEE()
+	br := io.TeeReader(pr, chksum)
+	decomp, e := newDecompressor(br, int(hdr.compressor))
 	if e != nil {
 		return nil, e
 	}
 
+	// Intake data.
+	var e1 error
+	go func() {
+		defer pw.Close()
+		_, e1 = io.CopyN(pw, r, int64(hdr.compressedSize))
+	}()
+
+	// Outtake data.
 	ch := &chunk{}
 	for i := 0; i < int(hdr.numRecords); i++ {
 		var rs [4]byte
-		if _, e = deflated.Read(rs[:]); e != nil {
+		if _, e = decomp.Read(rs[:]); e != nil {
 			return nil, fmt.Errorf("Failed to read record length: %v", e)
 		}
 
-		r := make([]byte, binary.LittleEndian.Uint32(rs[:]))
-		if _, e = deflated.Read(r); e != nil {
-			return nil, fmt.Errorf("Failed to read a record: %v", e)
+		l := binary.LittleEndian.Uint32(rs[:])
+		r := make([]byte, l)
+		if _, e = decomp.Read(r); e != nil {
+			if !(e == io.EOF && l == 0 && i == int(hdr.numRecords)-1) {
+				// Read returns EOF if an "" is at the end of a chunk.
+				return nil, fmt.Errorf("Failed to read a record: %v", e)
+			}
 		}
-
 		ch.records = append(ch.records, r)
 		ch.numBytes += len(r)
+	}
+
+	if e1 != nil {
+		return nil, e1
+	}
+
+	if hdr.checkSum != chksum.Sum32() {
+		return nil, fmt.Errorf("Checksum checking failed. %d vs %d", hdr.checkSum, chksum.Sum32())
 	}
 
 	return ch, nil
 }
 
-func deflateData(src io.Reader, compressorIndex int) (*bytes.Buffer, error) {
-	var e error
-	var deflator io.Reader
-
-	switch compressorIndex {
+func newDecompressor(src io.Reader, compressorID int) (io.Reader, error) {
+	switch compressorID {
 	case NoCompression:
-		deflator = src
+		return src, nil
 	case Snappy:
-		deflator = snappy.NewReader(src)
+		return snappy.NewReader(src), nil
 	case Gzip:
-		deflator, e = gzip.NewReader(src)
-		if e != nil {
-			return nil, fmt.Errorf("Failed to create gzip reader: %v", e)
-		}
-	default:
-		return nil, fmt.Errorf("Unknown compression algorithm: %d", compressorIndex)
+		return gzip.NewReader(src)
 	}
-
-	deflated := new(bytes.Buffer)
-	if _, e = io.Copy(deflated, deflator); e != nil {
-		return nil, fmt.Errorf("Failed to deflate chunk data: %v", e)
-	}
-
-	return deflated, nil
+	return nil, fmt.Errorf("Unknown compression algorithm: %d", compressorID)
 }

--- a/chunk.go
+++ b/chunk.go
@@ -60,7 +60,7 @@ func (ch *chunk) write(w io.Writer, compressorID int) error {
 // compress chunk data (records) into a buffer and returns the CRC32 checksum.
 func (ch *chunk) compress(compressorID int, buf *bytes.Buffer) (uint32, error) {
 	// In addition to notations introduced in the function
-	// definition parseChunk, we add the following:
+	// definition of read, we add the following:
 	//
 	// >(buf) : a bytes.Buffer is a writer.
 	// >(compr)> : a compressor wraps a writer into another writer.

--- a/reader.go
+++ b/reader.go
@@ -2,6 +2,7 @@ package recordio
 
 import (
 	"io"
+	"log"
 	"sort"
 )
 
@@ -115,7 +116,11 @@ func (s *Scanner) Scan() bool {
 	} else {
 		if ci, _ := s.index.Locate(s.cur); s.chunkIndex != ci {
 			s.chunkIndex = ci
-			s.chunk, s.err = parseChunk(s.reader, s.index.chunkOffsets[ci])
+			if _, e := s.reader.Seek(s.index.chunkOffsets[ci], io.SeekStart); e != nil {
+				log.Printf("Failed to seek chunk: %v", e)
+				return false
+			}
+			s.chunk, s.err = read(s.reader)
 		}
 	}
 

--- a/recordio_test.go
+++ b/recordio_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWriteRead(t *testing.T) {
-	const total = 1000
+	const total = 2000
 	var buf bytes.Buffer
 	w := recordio.NewWriter(&buf, -1, -1)
 	for i := 0; i < total; i++ {

--- a/writer.go
+++ b/writer.go
@@ -47,7 +47,7 @@ func (w *Writer) Write(record []byte) (int, error) {
 	}
 
 	if w.chunk.numBytes+len(record) > w.maxChunkSize {
-		if e := w.chunk.dump(w.Writer, w.compressor); e != nil {
+		if e := w.chunk.write(w.Writer, w.compressor); e != nil {
 			return 0, e
 		}
 	}
@@ -58,7 +58,7 @@ func (w *Writer) Write(record []byte) (int, error) {
 
 // Close flushes the current chunk and makes the writer invalid.
 func (w *Writer) Close() error {
-	e := w.chunk.dump(w.Writer, w.compressor)
+	e := w.chunk.write(w.Writer, w.compressor)
 	w.Writer = nil
 	return e
 }


### PR DESCRIPTION
The benchmark shows that this PR improves the reading speed for about 1000 times!

The benchmark on develop branch at this moment:

```
yi@WangYis-iMac:/go/src/github.com/wangkuiyi/recordio (develop)$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/wangkuiyi/recordio
BenchmarkRead/reading_records_00000_to_00050-4         	       5	 297171427 ns/op
BenchmarkRead/reading_records_00050_to_00100-4         	       3	 486892504 ns/op
BenchmarkRead/reading_records_00100_to_00150-4         	       5	 293632646 ns/op
PASS
ok  	github.com/wangkuiyi/recordio	8.859s
```

The benchmark of this PR:

```
yi@WangYis-iMac:/go/src/github.com/wangkuiyi/recordio (use_pipeline_in_io)$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/wangkuiyi/recordio
BenchmarkRead/reading_records_00000_to_00050-4         	    5000	    414011 ns/op
BenchmarkRead/reading_records_00050_to_00100-4         	    3000	    535504 ns/op
BenchmarkRead/reading_records_00100_to_00150-4         	    5000	    473778 ns/op
PASS
ok  	github.com/wangkuiyi/recordio	6.589s
```

The performance improvement hopefully fixes https://github.com/wangkuiyi/recordio/issues/50.