### PR TITLE
Add FileList and FileListScanner for async reading

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"log"
 
 	"github.com/golang/snappy"
 )
@@ -113,6 +114,8 @@ func newCompressor(w io.WriteCloser, compressorID int) io.WriteCloser {
 		return snappy.NewWriter(w)
 	case Gzip:
 		return gzip.NewWriter(w)
+	default:
+		log.Fatalf("Unknown compressor ID: %d", compressorID)
 	}
 	return nil
 }
@@ -170,10 +173,7 @@ func read(r io.Reader) (*chunk, error) {
 		r := make([]byte, l)
 		e := readNBytes(decomp, r)
 		if e != nil {
-			if !(e == io.EOF && l == 0 && i == int(hdr.numRecords)-1) {
-				// Read returns EOF if an "" is at the end of a chunk.
-				return nil, fmt.Errorf("Failed to read a record: %v", e)
-			}
+			return nil, fmt.Errorf("Failed to read a record: %v", e)
 		}
 		ch.records = append(ch.records, r)
 		ch.numBytes += len(r)

--- a/chunk.go
+++ b/chunk.go
@@ -117,11 +117,11 @@ func newCompressor(w io.WriteCloser, compressorID int) io.WriteCloser {
 	return nil
 }
 
-// read a chunk from r at the given offset.
-func read(r io.Reader) (*chunk, error) {
+// readChunk from r into the memory.
+func readChunk(r io.Reader) (*chunk, error) {
 	hdr, e := parseHeader(r)
 	if e != nil {
-		return nil, fmt.Errorf("Failed to parse chunk header: %v", e)
+		return nil, e // NOTE: must return e literally as required by FileListScanner.
 	}
 
 	// To help designing a complex I/O pipeline using Go's io

--- a/filelist.go
+++ b/filelist.go
@@ -1,0 +1,126 @@
+package recordio
+
+import (
+	"os"
+	"sort"
+
+	"github.com/wangkuiyi/parallel"
+)
+
+type FileList struct {
+	files         []string // filename list
+	indices       []*Index // index per file
+	accumFileLens []int    // accumulative file sizes in records
+}
+
+type FileListScanner struct {
+	fs         *FileList
+	start, end int         // A logical view of the range.
+	ch         chan string // From background reading goroutine to Next().
+	stop       chan int    // From Close() to the background goroutine.
+	err        error
+}
+
+// NewFileList build indices of a set of files.
+//
+// NOTE: If a caller is going to create to FileList objects that scan
+// the same set of files, it's the caller's responsibility to make
+// sure that the two fn parameters have files in the same order.
+func NewFileList(fn []string) (*FileList, error) {
+	idcs := make([]*Index, len(fn))
+
+	if e := parallel.For(0, len(fn), 1, func(i int) error {
+		f, e := os.Open(fn[i])
+		if e != nil {
+			return e
+		}
+		defer f.Close()
+
+		idcs[i], e = LoadIndex(f)
+		return e
+	}); e != nil {
+		return nil, e
+	}
+
+	accum := 0
+	accumFileLens := make([]int, len(fn))
+	for i, idx := range idcs {
+		accum += idx.NumRecords()
+		accumFileLens[i] = accum
+	}
+
+	return &FileList{
+		files:         fn,
+		indices:       idcs,
+		accumFileLens: accumFileLens}, nil
+}
+
+func (fs *FileList) Locate(recordIndex int) (file, chunk, record int) {
+	file = sort.Search(len(fs.accumFileLens), func(i int) bool {
+		return recordIndex < fs.accumFileLens[i]
+	})
+	if file >= len(fs.files) {
+		return -1, -1, -1
+	}
+
+	prevAccum := 0
+	if chunk > 0 {
+		prevAccum = fs.accumFileLens[file-1]
+	}
+
+	chunk, record = fs.indices[file].Locate(recordIndex - prevAccum)
+	return file, chunk, record
+
+}
+
+func (fs *FileList) TotalRecords() int {
+	if len(fs.accumFileLens) > 0 {
+		return fs.accumFileLens[len(fs.accumFileLens)-1]
+	}
+	return 0
+}
+
+func NewFileListScanner(fs *FileList, start, len int) *FileListScanner {
+	if start < 0 {
+		start = 0
+	}
+	if len < 0 {
+		len = fs.TotalRecords()
+	}
+
+	rs := &FileListScanner{
+		fs:    fs,
+		start: start,
+		end:   start + len,
+		ch:    make(chan string),
+		stop:  make(chan int)}
+
+	go func() { rs.err = rs.read() }()
+	return rs
+}
+
+func (scnr *FileListScanner) read() error {
+	// defer close(scnr.ch) // No more emits to ch after read returns,
+
+	// cur := scnr.start
+	// file, chunk, record := scnr.fs.Locate(cur)
+
+	// f, e := os.Open(scnr.fs.files[file])
+	// if e != nil {
+	// 	return e
+	// }
+
+	// idx := scnr.fs.indices[file]
+	// if _, e := f.Seek(idx.chunkOffsets[chunk], io.SeekStart); e != nil {
+	// 	return fmt.Errorf("Failed to seek to chunk: %v", e)
+	// }
+	return nil
+}
+
+func (*FileListScanner) Next() (string, error) {
+	return "", nil
+}
+
+func (fs *FileListScanner) Err() error {
+	return fs.err
+}

--- a/filelist.go
+++ b/filelist.go
@@ -16,11 +16,11 @@ type FileList struct {
 	accumFileLens []int    // accumulative file sizes in records
 }
 
-// NewFileList build indices of a set of files.
+// NewFileList builds indices of a set of files.
 //
-// NOTE: If a caller is going to create to FileList objects that scan
-// the same set of files, it's the caller's responsibility to make
-// sure that the two fn parameters have files in the same order.
+// NOTE: If a caller is going to create more than one FileList objects
+// that scan the same set of files, the caller must make sure that
+// they have the same file list of the same order in parameter fn.
 func NewFileList(fn []string) (*FileList, error) {
 	idcs := make([]*Index, len(fn))
 
@@ -91,15 +91,14 @@ func NewFileListScanner(fl *FileList, start, len int) *FileListScanner {
 	if start < 0 {
 		start = 0
 	}
-	end := start + len
-	if len < 0 {
-		end = fl.TotalRecords()
+	if len < 0 || start+len > fl.TotalRecords() {
+		len = fl.TotalRecords() - start
 	}
 
 	rs := &FileListScanner{
 		fl:    fl,
 		start: start,
-		end:   end,
+		end:   start + len,
 		ch:    make(chan []byte, 1000), // Buffer size is critial to performance. Currently ad-hoc.
 		stop:  make(chan int)}
 

--- a/filelist_test.go
+++ b/filelist_test.go
@@ -1,0 +1,60 @@
+package recordio
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func synthesizeFiles(nfiles int) (dir string, files []string, e error) {
+	dir, e = ioutil.TempDir("", "recordio-filelist-test")
+	if e != nil {
+		return "", nil, e
+	}
+
+	chunkSize := 10 * nfiles // The cap size of synthesized record.
+
+	for i := 0; i < nfiles; i++ {
+		fn := path.Join(dir, fmt.Sprintf("%05d.recordio", i))
+		files = append(files, fn)
+		f, e := os.Create(fn)
+		if e != nil {
+			return "", nil, e
+		}
+
+		w := NewWriter(f, chunkSize, Snappy)
+		for j := 0; j < i; j++ { // The i-th file contains i records.
+			r := make([]byte, j*10)
+			l, e := w.Write(r) // The first record in each file is empty.
+			if e != nil {
+				return "", nil, e
+			}
+			if l != len(r) {
+				return "", nil, fmt.Errorf("Writing %d byte, but did only %d", len(r), l)
+			}
+		}
+		w.Close() // closes file automatically.
+	}
+	return dir, files, nil
+}
+
+func TestNewFileList(t *testing.T) {
+	a := assert.New(t)
+
+	nfiles := 10
+	dir, files, e := synthesizeFiles(nfiles)
+	a.NoError(e)
+	a.Equal(nfiles, len(files))
+	defer os.RemoveAll(dir)
+
+	fl, e := NewFileList(files)
+	a.NoError(e)
+	for i := range files {
+		a.Equal(i, fl.indices[i].NumRecords())
+	}
+	a.Equal(nfiles*(nfiles-1)/2, fl.TotalRecords())
+}

--- a/filelist_test.go
+++ b/filelist_test.go
@@ -6,17 +6,19 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func synthesizeFiles(nfiles int) (dir string, files []string, e error) {
+func synthesizeFiles() (dir string, files []string, e error) {
+	nfiles := 10
+	chunkSize := 10 * nfiles // The cap size of synthesized record.
+
 	dir, e = ioutil.TempDir("", "recordio-filelist-test")
 	if e != nil {
 		return "", nil, e
 	}
-
-	chunkSize := 10 * nfiles // The cap size of synthesized record.
 
 	for i := 0; i < nfiles; i++ {
 		fn := path.Join(dir, fmt.Sprintf("%05d.recordio", i))
@@ -29,7 +31,7 @@ func synthesizeFiles(nfiles int) (dir string, files []string, e error) {
 		w := NewWriter(f, chunkSize, Snappy)
 		for j := 0; j < i; j++ { // The i-th file contains i records.
 			r := make([]byte, j*10)
-			l, e := w.Write(r) // The first record in each file is empty.
+			l, e := w.Write(r) // The first record since the second file is empty.
 			if e != nil {
 				return "", nil, e
 			}
@@ -45,10 +47,8 @@ func synthesizeFiles(nfiles int) (dir string, files []string, e error) {
 func TestNewFileList(t *testing.T) {
 	a := assert.New(t)
 
-	nfiles := 10
-	dir, files, e := synthesizeFiles(nfiles)
+	dir, files, e := synthesizeFiles()
 	a.NoError(e)
-	a.Equal(nfiles, len(files))
 	defer os.RemoveAll(dir)
 
 	fl, e := NewFileList(files)
@@ -56,5 +56,64 @@ func TestNewFileList(t *testing.T) {
 	for i := range files {
 		a.Equal(i, fl.indices[i].NumRecords())
 	}
+	nfiles := len(files)
 	a.Equal(nfiles*(nfiles-1)/2, fl.TotalRecords())
+
+	scnr := NewFileListScanner(fl, -1, -1)
+	a.NoError(scnr.Error())
+
+	n := 0
+	for range scnr.Chan() {
+		n++
+	}
+	a.Equal(nfiles*(nfiles-1)/2, n)
+	a.NoError(scnr.Error())
+}
+
+func BenchmarkSyncAndAsyncRead(b *testing.B) {
+	const records = 200
+
+	fn, e := synthesizeTempFile(records)
+	if e != nil {
+		b.Fatalf("Cannot synthesize RecordIO file for benchmarking: %v", e)
+	}
+	defer os.Remove(fn)
+
+	f, e := os.Open(fn)
+	if e != nil {
+		b.Fatalf("Cannot open synthesized file %s: %v", fn, e)
+	}
+
+	idx, e := LoadIndex(f)
+	if e != nil {
+		b.Fatalf("Failed indexing synthesized file %s: %v", fn, e)
+	}
+
+	workload := time.Duration(2) * time.Millisecond
+
+	b.Run("Synch reading",
+		func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				scnr := NewScanner(f, idx, -1, -1)
+				for scnr.Scan() {
+					scnr.Record()
+					time.Sleep(workload) // mimic workload
+				}
+			}
+		})
+
+	fl, e := NewFileList([]string{fn})
+	if e != nil {
+		b.Fatalf("NewFileList failed: %v", e)
+	}
+
+	b.Run("Async reading",
+		func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				scnr := NewFileListScanner(fl, -1, -1)
+				for range scnr.Chan() {
+					time.Sleep(workload) // mimic workload
+				}
+			}
+		})
 }

--- a/reader.go
+++ b/reader.go
@@ -120,7 +120,7 @@ func (s *Scanner) Scan() bool {
 				log.Printf("Failed to seek chunk: %v", e)
 				return false
 			}
-			s.chunk, s.err = read(s.reader)
+			s.chunk, s.err = readChunk(s.reader)
 		}
 	}
 


### PR DESCRIPTION
Currently, [`Scanner.Scan`](https://github.com/wangkuiyi/recordio/blob/cb641daebc9dd23b7983f43ae129ece8890fbc18/reader.go#L111-L128) reads data synchronously and we need to create a Scanner for each file.

This PR adds a new type `FileList` and `FileListScanner` that logically concatenates files into a single record stream and allows scanning a segment of this logical stream.  More importantly, `FileListScanner.Scan` reads data asynchronously.

This PR also adds a benchmark that compares the synchronous and asynchronous reading, assuming each record needs a small amount of time to "consume" it.  The comparison result is as follows:

```
yi@WangYis-iMac:/go/src/github.com/wangkuiyi/recordio (async_read)*$ go test -bench=SyncAndAsync
goos: darwin
goarch: amd64
pkg: github.com/wangkuiyi/recordio
BenchmarkSyncAndAsyncRead/Synch_reading-4         	       2	 795081294 ns/op
BenchmarkSyncAndAsyncRead/Async_reading-4         	       3	 490042952 ns/op
PASS
ok  	github.com/wangkuiyi/recordio	9.004s
```

It seems that the async reading is about twice the speed comparing to sync reading.