### PR TITLE
Fix the failure reading old files

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -158,15 +158,7 @@ func readChunk(r io.Reader) (*chunk, error) {
 	var e1 error
 	go func() {
 		defer pw.Close()
-		todo := int64(hdr.compressedSize)
-		for todo > 0 {
-			n, e := io.CopyN(pw, r, todo)
-			if e != nil {
-				e1 = e
-				return
-			}
-			todo -= n
-		}
+		_, e1 = io.CopyN(pw, r, int64(hdr.compressedSize))
 	}()
 
 	// Outtake data.


### PR DESCRIPTION
@skydoorkai reported a bug that when we use the most recent code to read a RecordIO file generated weeks ago, it fails.

I reproduced the error and noticed that all records in that file have the same size. However, the reading would stop when reading a record as it thinks the record length is an extremely large value.

I went over the code and realized the reading of the record length calls the old `io.Reader.Read` instead of `readNBytes`. After correcting the call, the newest code can read the old file.